### PR TITLE
Add built-in function parseInt

### DIFF
--- a/src/codegen/call-expression.ts
+++ b/src/codegen/call-expression.ts
@@ -16,12 +16,20 @@ export default class CodeGenFuncDecl {
     const callArgs = node.arguments.map(item => this.cgen.genExpression(item));
 
     switch (funcName) {
+      case 'atoi':
+        return this.cgen.stdlib.atoi(callArgs);
       case 'console.log':
         return this.cgen.stdlib.printf(callArgs);
+      case 'itoa':
+        return this.cgen.stdlib.itoa(callArgs);
       case 'malloc':
         return this.cgen.stdlib.malloc(callArgs);
+      case 'parseInt':
+        return this.cgen.stdlib.atoi(callArgs);
       case 'printf':
         return this.cgen.stdlib.printf(callArgs);
+      case `sprintf`:
+        return this.cgen.stdlib.sprintf(callArgs);
       case 'strcat':
         return this.cgen.stdlib.strcat(callArgs);
       case 'strcmp':

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -70,8 +70,8 @@ export default class LLVMCodeGen {
   public currentFunction: llvm.Function | undefined;
   public currentType: ts.TypeNode | undefined;
 
-  constructor(full: string[]) {
-    this.program = ts.createProgram(full, {});
+  constructor(main: string) {
+    this.program = ts.createProgram([main], {});
     this.checker = this.program.getTypeChecker();
 
     this.context = new llvm.LLVMContext();

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ function build(args: any, opts: any): BuildInfo {
   const prelude = new Prelude(args);
   const outputs = prelude.process();
 
-  const codegen = new LLVMCodeGen([outputs]);
+  const codegen = new LLVMCodeGen(outputs);
   const triple: string = opts.triple ? opts.triple : llvm.config.LLVM_DEFAULT_TARGET_TRIPLE;
   const target = llvm.TargetRegistry.lookupTarget(triple);
   const m = target.createTargetMachine(triple, 'generic');

--- a/src/prelude.ts
+++ b/src/prelude.ts
@@ -956,8 +956,7 @@ class PreludeLayer4 extends Base {
         throw new Error('Array type must be specified explicitly');
       }
       if (a.flags & ts.TypeFlags.Object && a.symbol.escapedName.toString() !== '__object') {
-        const b = (node.initializer as ts.NewExpression).expression.getText();
-        return ts.createTypeReferenceNode(b, undefined);
+        return ts.createTypeReferenceNode(a.symbol.escapedName.toString(), undefined);
       }
       return undefined;
     })();

--- a/src/prelude.ts
+++ b/src/prelude.ts
@@ -1096,6 +1096,7 @@ export default class Prelude {
     option.entryfn = new PreludeLayer4(option).process();
     option.entryfn = new PreludeLayer5(option).process();
     const out = path.join(tempdir, 'output.ts');
+    debug(`Rename ${option.entryfn} => ${out}`);
     fs.copyFileSync(option.entryfn, out);
     return out;
   }

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -9,6 +9,34 @@ export class Stdlib {
     this.cgen = cgen;
   }
 
+  public atoi(args: llvm.Value[]): llvm.Value {
+    const name = 'atoi';
+    const i = [llvm.Type.getInt8PtrTy(this.cgen.context)];
+    const varg = false;
+    const o = llvm.Type.getInt64Ty(this.cgen.context);
+    const func = this.cgen.module.getOrInsertFunction(name, llvm.FunctionType.get(o, i, varg));
+    return this.cgen.builder.createCall(func, args);
+  }
+
+  // Warning: implicit declaration of function 'itoa' is invalid in C99
+  public itoa(args: llvm.Value[]): llvm.Value {
+    const name = 'itoa';
+    const i: llvm.Type[] = [];
+    const varg = true;
+    const o = llvm.Type.getInt64Ty(this.cgen.context);
+    const func = this.cgen.module.getOrInsertFunction(name, llvm.FunctionType.get(o, i, varg));
+    const dest = llvm.FunctionType.get(
+      llvm.Type.getInt64Ty(this.cgen.context),
+      [
+        llvm.Type.getInt64Ty(this.cgen.context),
+        llvm.Type.getInt8PtrTy(this.cgen.context),
+        llvm.Type.getInt64Ty(this.cgen.context)
+      ],
+      true
+    );
+    return this.cgen.builder.createCall(this.cgen.builder.createBitCast(func, dest.getPointerTo()), args);
+  }
+
   public malloc(args: llvm.Value[]): llvm.Value {
     const name = 'malloc';
     const i = [llvm.Type.getInt64Ty(this.cgen.context)];
@@ -21,6 +49,15 @@ export class Stdlib {
   public printf(args: llvm.Value[]): llvm.Value {
     const name = 'printf';
     const i = [llvm.Type.getInt8PtrTy(this.cgen.context)];
+    const varg = true;
+    const o = llvm.Type.getInt64Ty(this.cgen.context);
+    const func = this.cgen.module.getOrInsertFunction(name, llvm.FunctionType.get(o, i, varg));
+    return this.cgen.builder.createCall(func, args);
+  }
+
+  public sprintf(args: llvm.Value[]): llvm.Value {
+    const name = 'sprintf';
+    const i = [llvm.Type.getInt8PtrTy(this.cgen.context), llvm.Type.getInt8PtrTy(this.cgen.context)];
     const varg = true;
     const o = llvm.Type.getInt64Ty(this.cgen.context);
     const func = this.cgen.module.getOrInsertFunction(name, llvm.FunctionType.get(o, i, varg));

--- a/src/tests/binary.spec.ts
+++ b/src/tests/binary.spec.ts
@@ -29,10 +29,11 @@ test('test args', async t => {
 
   const prelude = new Prelude(name);
   const outputs = prelude.process();
-  const codegen = new LLVMCodeGen([outputs]);
+  const codegen = new LLVMCodeGen(outputs);
   codegen.genSourceFile(outputs);
 
   const full = path.join(path.dirname(outputs), 'output');
+  fs.writeFileSync(`${full}.ll`, codegen.genText());
   shell.exec(`llvm-as ${full}.ll -o ${full}.bc`, { async: false });
   shell.exec(`llc -filetype=obj ${full}.bc -o ${full}.o`, { async: false });
   shell.exec(`gcc ${full}.o -o ${full}`, { async: false });

--- a/src/tests/int8array.spec.ts
+++ b/src/tests/int8array.spec.ts
@@ -15,5 +15,17 @@ function main(): number {
 }
 `;
 
+const srcReturnByFunction = `
+function func(): Int8Array {
+    return new Int8Array([0, 1, 2, 3]);
+}
+
+function main(): number {
+    const r = func();
+    return r[3];
+}
+`;
+
 runTest('test buffer: get and set', srcGetAndSet);
 runTest('test buffer: new with number array', srcNewWithNumberArray);
+runTest('test buffer: return by func', srcReturnByFunction);

--- a/src/tests/stdlib.spec.ts
+++ b/src/tests/stdlib.spec.ts
@@ -14,4 +14,14 @@ function main(): number {
 }
 `;
 
+const srcAtoI = `
+function main(): number {
+    const s = "100";
+    let d: number = parseInt(s);
+    d += 5; // 105
+    return d;
+}
+`;
+
 runTest('test stdlib: console.log', srcConsoleLog);
+runTest('test stdlib: atoi', srcAtoI);

--- a/src/tests/util.ts
+++ b/src/tests/util.ts
@@ -38,7 +38,7 @@ async function runWithLLVM(source: string): Promise<any> {
 
   const prelude = new Prelude(name);
   const outputs = prelude.process();
-  const codegen = new LLVMCodeGen([outputs]);
+  const codegen = new LLVMCodeGen(outputs);
   codegen.genSourceFile(outputs);
 
   const tmppath = path.join(path.dirname(outputs), 'output.ll');


### PR DESCRIPTION
js's `parseInt` is an alias for c's `atoi`.

```ts
function main(): number {
    const s = "100";
    let d: number = parseInt(s);
    d += 5; // 105
    return d;
}
```